### PR TITLE
add SampleCreate, SampleUpdate, and SampleRead classes for Pydantic

### DIFF
--- a/backend/app/schemas/sample_schema.py
+++ b/backend/app/schemas/sample_schema.py
@@ -4,27 +4,42 @@ from datetime import datetime
 from pydantic import BaseModel, Field, StringConstraints
 from app.models.sample import SampleStatus
 
-class SampleBase(BaseModel):
-    sample_id: Annotated[
-           str, 
-           Field(..., description="Unique sample ID"), 
-           StringConstraints(min_length=1, pattern=r'^[a-zA-Z0-9_-]+$')
-        ]
-    
-    source: Annotated[
-            str, 
-            Field(..., description="Source or origin of the sample"),
-            StringConstraints(min_length=1)
-        ]
-    
-    status: SampleStatus = Field(..., description="Status of the sample (pending, in-progress, complete)")
+alphanumeric_str = Annotated[str, StringConstraints(min_length=1, pattern=r'^[a-zA-Z0-9_-]+$')]
+alpha_str = Annotated[str, StringConstraints(min_length=1, pattern=r'^[a-zA-Z]+$')]
+nonempty_str = Annotated[str, StringConstraints(min_length=1)]
 
-    type: Annotated[
-            str, 
-            Field(..., description="Sample type, e.g., blood, powder, etc."), 
-            StringConstraints(min_length=1, pattern=r'^[a-zA-Z]+$')
-        ]
+class SampleBase(BaseModel):
+    sample_id: alphanumeric_str = Field(description="Unique sample ID")
     
-    assigned_user_id: Optional[UUID] = Field(..., description="Optional UUID of the assigned user")
+    source: nonempty_str = Field(description="Source or origin of the sample")
     
-    date_collected: datetime = Field(..., description="Date the sample was collected or received")
+    status: SampleStatus = Field(description="Status of the sample (pending, in-progress, complete)")
+
+    type: alpha_str = Field(description="Sample type, e.g., blood, powder, etc.")
+    
+    assigned_user_id: Optional[UUID] = Field(None, description="Optional UUID of the assigned user")
+    
+    date_collected: datetime = Field(description="Date the sample was collected or received")
+
+class SampleCreate(SampleBase):
+    pass
+
+class SampleUpdate(SampleBase):
+    sample_id: Optional[alphanumeric_str] = Field(None, description="Unique sample ID")
+    
+    source: Optional[nonempty_str] = Field(None, description="Source or origin of the sample")
+    
+    status: Optional[SampleStatus] = Field(None, description="Status of the sample (pending, in-progress, complete)")
+
+    type: Optional[alpha_str] = Field(None, description="Sample type, e.g., blood, powder, etc.")
+    
+    assigned_user_id: Optional[UUID] = Field(None, description="Optional UUID of the assigned user")
+    
+    date_collected: Optional[datetime] = Field(None, description="Date the sample was collected or received")
+
+class SampleRead(SampleBase):
+    id: UUID = Field(description="Primary key id")
+
+    created_at: datetime = Field(description="Time sample was created")
+
+    updated_at: datetime = Field(description="Most recent time sample was updated")


### PR DESCRIPTION
This PR adds the following Pydantic schema classes to support validation of sample-related data in the FastAPI backend:

- SampleCreate: Fields required for creating a new sample
- SampleUpdate: All fields optional for partial updates (PATCH/PUT)
- SampleRead: Extends SampleBase with system fields (id, created_at, updated_at)

closes #6 